### PR TITLE
Move Plausible analytics page ID to environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Plausible Analytics Configuration
+# Get your page ID from your Plausible account settings
+# This is used to identify the page in Plausible analytics tracking events
+PLAUSIBLE_PAGE_ID=your_plausible_page_id_here

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,8 @@ jobs:
           cd components/Styling && npm install
         
       - name: Build
+        env:
+          PLAUSIBLE_PAGE_ID: ${{ secrets.PLAUSIBLE_PAGE_ID }}
         run: npm run build
 
       - name: Upload Pages artifact

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,9 +57,6 @@ jobs:
             exit 1
           fi
 
-      - name: Validate HTML
-        run: npx htmlhint "public/**/*.html"
-
       - name: Upload Pages artifact
         if: github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,29 @@ jobs:
       - name: Build
         env:
           PLAUSIBLE_PAGE_ID: ${{ secrets.PLAUSIBLE_PAGE_ID }}
-        run: npm run build
+        run: |
+          if [ -z "$PLAUSIBLE_PAGE_ID" ]; then
+            echo "ERROR: PLAUSIBLE_PAGE_ID is not set in GitHub secrets"
+            exit 1
+          fi
+          echo "Building with Plausible page ID configured..."
+          npm run build
+
+      - name: Verify Build Output
+        run: |
+          if [ ! -f "public/js/main.js" ]; then
+            echo "ERROR: JavaScript bundle not found at public/js/main.js"
+            exit 1
+          fi
+          if grep -q "pageID" public/js/main.js; then
+            echo "✓ Plausible pageID found in JavaScript bundle"
+          else
+            echo "ERROR: pageID not found in bundle"
+            exit 1
+          fi
+
+      - name: Validate HTML
+        run: npx htmlhint "public/**/*.html"
 
       - name: Upload Pages artifact
         if: github.ref == 'refs/heads/main'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,42 @@ The support section uses a custom collection that:
 - **Plausible Analytics**: Privacy-focused analytics integration
 - **Form tracking**: Signup form submissions tracked with custom events
 
+## Environment Variables
+
+### Required Configuration
+
+The project requires the following environment variable:
+
+- **PLAUSIBLE_PAGE_ID**: Your Plausible Analytics page ID for tracking analytics events
+
+### Local Development Setup
+
+1. Copy the example environment file:
+   ```bash
+   cp .env.example .env
+   ```
+
+2. Edit `.env` and set your Plausible page ID:
+   ```
+   PLAUSIBLE_PAGE_ID=your_actual_page_id_here
+   ```
+
+3. The environment variable is loaded by webpack during the build process via `dotenv`
+4. The value is compiled into the JavaScript bundle at `public/js/main.js`
+5. If the variable is not set, you'll see a warning during the build, and analytics tracking will be disabled
+
+### Environment Variable Flow
+
+1. **Local Development**:
+   - `.env` file in project root → `dotenv.config()` in `components/Styling/webpack.config.ts`
+   - Webpack's DefinePlugin injects the value as `process.env.PLAUSIBLE_PAGE_ID`
+   - Used in `components/Styling/scripts/index.ts` for analytics tracking
+
+2. **CI/CD (GitHub Actions)**:
+   - Set `PLAUSIBLE_PAGE_ID` in repository secrets (Settings → Secrets and variables → Actions)
+   - The workflow passes the secret to the build environment
+   - CI includes verification steps to ensure the variable is set and appears in the bundle
+
 ## Development Notes
 
 ### Content Updates

--- a/components/Styling/package-lock.json
+++ b/components/Styling/package-lock.json
@@ -32,6 +32,9 @@
         "typescript": "^4.7.4",
         "webpack": "^5.74.0",
         "webpack-cli": "^4.10.0"
+      },
+      "devDependencies": {
+        "dotenv": "^17.2.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2902,6 +2905,19 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
+      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -8126,6 +8142,12 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "dotenv": {
+      "version": "17.2.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
+      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
+      "dev": true
     },
     "electron-to-chromium": {
       "version": "1.4.544",

--- a/components/Styling/package.json
+++ b/components/Styling/package.json
@@ -30,5 +30,8 @@
     "publish": "webpack"
   },
   "author": "",
-  "license": "ISC"
+  "license": "ISC",
+  "devDependencies": {
+    "dotenv": "^17.2.3"
+  }
 }

--- a/components/Styling/scripts/index.ts
+++ b/components/Styling/scripts/index.ts
@@ -2,7 +2,7 @@ import "./../styles/styles.css";
 
 import Plausible from "plausible-tracker";
 
-const pageID = "7d44e5cdd9bf0241d295591162f4c69ac1de5e09";
+const pageID = process.env.PLAUSIBLE_PAGE_ID || "";
 
 const plausible = Plausible({
   domain: "getbushel.app",

--- a/components/Styling/webpack.config.ts
+++ b/components/Styling/webpack.config.ts
@@ -7,6 +7,13 @@ import dotenv from "dotenv";
 // Load environment variables from root .env file
 dotenv.config({ path: path.resolve(__dirname, "../../.env") });
 
+// Validate PLAUSIBLE_PAGE_ID is set
+const plausiblePageId = process.env.PLAUSIBLE_PAGE_ID;
+if (!plausiblePageId) {
+  console.warn('\n⚠️  Warning: PLAUSIBLE_PAGE_ID environment variable is not set.');
+  console.warn('   Analytics tracking will be disabled. See .env.example for setup instructions.\n');
+}
+
 const config: Configuration = {
   entry: "./scripts/index.ts",
   output: {

--- a/components/Styling/webpack.config.ts
+++ b/components/Styling/webpack.config.ts
@@ -1,6 +1,11 @@
 import path from "path";
 import { Configuration } from "webpack";
 import ESLintPlugin from "eslint-webpack-plugin";
+import webpack from "webpack";
+import dotenv from "dotenv";
+
+// Load environment variables from root .env file
+dotenv.config({ path: path.resolve(__dirname, "../../.env") });
 
 const config: Configuration = {
   entry: "./scripts/index.ts",
@@ -33,9 +38,14 @@ const config: Configuration = {
   resolve: {
     extensions: [".ts", ".js"],
   },
-  plugins:  [new ESLintPlugin({
-    extensions : [".ts", ".js"]
-  })]
+  plugins:  [
+    new ESLintPlugin({
+      extensions : [".ts", ".js"]
+    }),
+    new webpack.DefinePlugin({
+      "process.env.PLAUSIBLE_PAGE_ID": JSON.stringify(process.env.PLAUSIBLE_PAGE_ID || ""),
+    })
+  ]
 };
 
 export default config;


### PR DESCRIPTION
- Configure webpack to inject PLAUSIBLE_PAGE_ID from .env file
- Update index.ts to use environment variable instead of hardcoded value
- Add dotenv package for environment variable loading
- Update GitHub Actions workflow to use PLAUSIBLE_PAGE_ID secret
- Keep analytics ID out of repository for security

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/brightdigit/getbushel.app/15)
<!-- GitContextEnd -->